### PR TITLE
Add AmIIgnoredCommand

### DIFF
--- a/src/main/java/net/simpvp/ignore/AmIIgnoredCommand.java
+++ b/src/main/java/net/simpvp/ignore/AmIIgnoredCommand.java
@@ -1,0 +1,55 @@
+package net.simpvp.ignore;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class AmIIgnoredCommand implements CommandExecutor {
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		Player player = null;
+		if (sender instanceof Player) {
+			player = (Player) sender;
+		}
+
+		if (player == null) {
+			Ignore.instance.getLogger().info(
+					"Only players can use this command.");
+			return true;
+		}
+
+		if (args.length != 1) {
+			send_message(player, ChatColor.RED,
+					"Incorrect number of arguments.\n"
+							+ "Usage: /amiignored <player>");
+		} else {
+			Player target = Ignore.instance.getServer()
+					.getPlayer(args[0]);
+
+			if (target == null) {
+				send_message(player, ChatColor.RED,
+						"There is no player with that name online.");
+				return true;
+			}
+
+			if (Storage.getIsIgnoring(target, player)) {
+				send_message(player, ChatColor.WHITE, "You are being ignored by that player.");
+			} else {
+				send_message(player, ChatColor.WHITE, "You are not being ignored by that player.");
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private void send_message(Player player, ChatColor color, String msg) {
+		player.sendMessage(color + msg);
+		Ignore.instance.getLogger().info(msg);
+	}
+
+}

--- a/src/main/java/net/simpvp/ignore/Ignore.java
+++ b/src/main/java/net/simpvp/ignore/Ignore.java
@@ -23,6 +23,7 @@ public class Ignore extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(new ChatListener(), this);
 		getServer().getPluginManager().registerEvents(new PlayerJoin(), this);
 		getCommand("ignore").setExecutor(new IgnoreCommand());
+		getCommand("amiignored").setExecutor(new AmIIgnoredCommand());
 		getCommand("me").setExecutor(new MeCommand());
 		getCommand("tell").setExecutor(new TellCommand());
 		getCommand("servertell").setExecutor(new ServertellCommand());

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,8 @@ description: Lets players ignore other players.
 commands:
   Ignore:
     description: (Un)ignores target player.
+  AmIIgnored:
+    description: Queries if a player is ignoring you.
   Me:
     description: Duplicate of vanilla /me with ignore support
   Tell:


### PR DESCRIPTION
Adds a simple `amiignored` command to query whether or not a player is ignoring you. This is especially useful when your messages aren't getting through and you just don't know whether or not the player you're talking to has ignored you.