### PR TITLE
Handle illegal characters in URLs

### DIFF
--- a/src/main/java/net/simpvp/ignore/Chat.java
+++ b/src/main/java/net/simpvp/ignore/Chat.java
@@ -132,9 +132,16 @@ public class Chat {
 					url = "https://" + arg;
 				}
 
-				TextComponent link = new TextComponent(arg);
-				link.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url));
-				ret.addExtra(link);
+				try {
+					new java.net.URI(url);
+
+					TextComponent link = new TextComponent(arg);
+					link.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, url));
+					ret.addExtra(link);
+
+				} catch (Exception e) {
+					ret.addExtra(arg);
+				}
 
 			} else {
 				c += arg;


### PR DESCRIPTION
Messages containing invalid URL characters and periods within the same token will throw:
`com.google.gson.JsonParseException: Illegal character in authority at index n:`

This causes many messages to fail to send, such as those containing: `".`

This change just catches the bad URL and sends the message as regular text.