### PR TITLE
Add ignore-death feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,16 +16,16 @@
 	</properties>
 	<repositories>
 		<repository>
-			<id>spigot-repo</id>
-			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+			<id>papermc-repo</id>
+			<url>https://repo.papermc.io/repository/maven-public/</url>
 		</repository>
 	</repositories>
 
 	<dependencies>
 		<dependency>
-			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot-api</artifactId>
-			<version>1.16.4-R0.1-SNAPSHOT</version>
+			<groupId>io.papermc.paper</groupId>
+			<artifactId>paper-api</artifactId>
+			<version>1.21.1-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/net/simpvp/ignore/DeathListener.java
+++ b/src/main/java/net/simpvp/ignore/DeathListener.java
@@ -1,0 +1,39 @@
+package net.simpvp.ignore;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+
+/**
+ * Filters death messages based on ignore and ignore-death settings,
+ * while preserving the original message data (hover, lore, etc).
+ */
+public class DeathListener implements Listener {
+
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onPlayerDeath(PlayerDeathEvent event) {
+		Component msg = event.deathMessage();
+		if (msg == null) {
+			return;
+		}
+
+		Player dead = event.getEntity();
+		event.deathMessage(null);
+
+		String plain = PlainTextComponentSerializer.plainText().serialize(msg);
+		Bukkit.getLogger().info(plain);
+
+		for (Player p : Bukkit.getOnlinePlayers()) {
+			if (Storage.getIgnoreDeath(p) && Storage.getIsIgnoring(p, dead)) {
+				continue;
+			}
+
+			p.sendMessage(msg);
+		}
+	}
+}

--- a/src/main/java/net/simpvp/ignore/Ignore.java
+++ b/src/main/java/net/simpvp/ignore/Ignore.java
@@ -19,9 +19,11 @@ public class Ignore extends JavaPlugin {
 			dir.mkdir();
 		}
 		SQLite.connect();
+		Storage.initIgnoreDeath(SQLite.get_ignore_death_all());
 
 		getServer().getPluginManager().registerEvents(new ChatListener(), this);
 		getServer().getPluginManager().registerEvents(new PlayerJoin(), this);
+		getServer().getPluginManager().registerEvents(new DeathListener(), this);
 		getCommand("ignore").setExecutor(new IgnoreCommand());
 		getCommand("me").setExecutor(new MeCommand());
 		getCommand("tell").setExecutor(new TellCommand());
@@ -32,6 +34,7 @@ public class Ignore extends JavaPlugin {
 		getCommand("m").setExecutor(new PMCommands());
 		getCommand("lastlog").setExecutor(new LastLog());
 		getCommand("report").setExecutor(new ReportCommand());
+		getCommand("ignoredeath").setExecutor(new IgnoreDeathCommand());
 	}
 
 	public void onDisable() {

--- a/src/main/java/net/simpvp/ignore/IgnoreDeathCommand.java
+++ b/src/main/java/net/simpvp/ignore/IgnoreDeathCommand.java
@@ -1,0 +1,58 @@
+package net.simpvp.ignore;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Toggles whether death messages from ignored players are hidden.
+ */
+public class IgnoreDeathCommand implements CommandExecutor {
+
+	@Override
+	public boolean onCommand(CommandSender sender,
+			Command cmd,
+			String label,
+			String[] args) {
+
+		Player player = null;
+		if (sender instanceof Player) {
+			player = (Player) sender;
+		}
+
+		if (player == null) {
+			Ignore.instance.getLogger().info(
+					"Only players can use this command.");
+			return true;
+		}
+
+		if (args.length != 0) {
+			send_message(player, ChatColor.RED,
+					"Incorrect number of arguments.\n"
+					+ "Usage: /ignoredeath");
+			return true;
+		}
+
+		boolean currentValue = Storage.getIgnoreDeath(player);
+		boolean newValue = !currentValue;
+
+		Storage.setIgnoreDeath(player, newValue);
+		SQLite.set_ignore_death(player.getUniqueId(), newValue);
+
+		if (newValue) {
+			send_message(player, ChatColor.GOLD,
+					"Death messages from ignored players will be hidden.");
+		} else {
+			send_message(player, ChatColor.GOLD,
+					"Death messages from ignored players will be shown.");
+		}
+		return true;
+	}
+
+	private void send_message(Player player, ChatColor color, String msg) {
+		player.sendMessage(color + msg);
+		// Ignore.instance.getLogger().info(msg);
+	}
+}

--- a/src/main/java/net/simpvp/ignore/Storage.java
+++ b/src/main/java/net/simpvp/ignore/Storage.java
@@ -21,6 +21,10 @@ public class Storage {
 	private static HashMap<UUID, HashSet<String>> ignoringMap
 		= new HashMap<UUID, HashSet<String>>();
 
+	/* Players who have ignore-death enabled */
+	private static HashSet<UUID> ignoreDeathSet
+		= new HashSet<UUID>();
+
 	/**
 	 * Returns whether player is ignored by anybody.
 	 * @param uuid Player to check if is ignored.
@@ -118,6 +122,35 @@ public class Storage {
 
 		ignoring.add(ignored_name);
 		ignoringMap.put(ignorer, ignoring);
+	}
+
+	/**
+	 * Returns whether player has ignore-death enabled.
+	 */
+	public static boolean getIgnoreDeath(Player player) {
+		return ignoreDeathSet.contains(player.getUniqueId());
+	}
+
+	/**
+	 * Sets whether player has ignore-death enabled.
+	 */
+	public static void setIgnoreDeath(Player player, boolean enabled) {
+		UUID uuid = player.getUniqueId();
+		if (enabled) {
+			ignoreDeathSet.add(uuid);
+		} else {
+			ignoreDeathSet.remove(uuid);
+		}
+	}
+
+	/**
+	 * Initializes ignore-death state from db.
+	 */
+	public static void initIgnoreDeath(HashSet<UUID> uuids) {
+		ignoreDeathSet.clear();
+		if (uuids != null) {
+			ignoreDeathSet.addAll(uuids);
+		}
 	}
 }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -25,3 +25,5 @@ commands:
     description: Show last messages sent to you
   Report:
     description: Report something to the admins
+  Ignoredeath:
+    description: Toggle hiding death messages from ignored players


### PR DESCRIPTION
Allows players to toggle whether death messages are hidden from ignored players, a popular suggested feature